### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
   run-efsity-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
 
       - name: Run Unit Tests and Generate Coverage Report
         run: ./gradlew test jacocoTestReport
@@ -28,13 +28,13 @@ jobs:
   run-spotless-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
 
       - name: Run spotless check
         run: ./gradlew spotlessCheck
@@ -43,7 +43,7 @@ jobs:
   run-importer-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate Importer Report
         run: |
@@ -52,15 +52,13 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-cov
-          pytest --doctest-modules --junitxml=coverage.xml --cov=. --cov-report=xml --cov-report=html
-          coverage xml
-          ls -al
+          pytest --doctest-modules --cov=.
         working-directory: importer
 
   run-cleaner-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate Cleaner Report
         run: |
@@ -69,7 +67,5 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-cov
-          pytest --doctest-modules --junitxml=coverage.xml --cov=. --cov-report=xml --cov-report=html
-          coverage xml
-          ls -al
+          pytest --doctest-modules --cov=.
         working-directory: cleaner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 11
 
       - name: Run Unit Tests and Generate Coverage Report
         run: ./gradlew test jacocoTestReport
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'


### PR DESCRIPTION
- Update actions versions
- Have coverage output directly instead of sent to file

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #[issue number] or Closes #[issue number]

**Engineer Checklist**
- [ ] I have run `./gradlew spotlessApply` to check my code follows the project's style guide
- [ ] I have built and run the efsity jar to verify my change fixes the issue and/or does not break the application 

