### PR TITLE
[Uploader] Use jq -r to get resource type without quote

### DIFF
--- a/uploader/uploader.sh
+++ b/uploader/uploader.sh
@@ -2,8 +2,7 @@
 
 push_to_server() {
     # Get the resource type
-    RESOURCE_TYPE=$(cat "$@" | jq '.resourceType')
-    RESOURCE_TYPE="${RESOURCE_TYPE:1:-1}"
+    RESOURCE_TYPE=$(cat "$@" | jq -r '.resourceType')
 
     # Post to server
     SERVER_URL="$SERVER_URL/${RESOURCE_TYPE}"


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes #275

**Engineer Checklist**
- [ ] I have run `./gradlew spotlessApply` to check my code follows the project's style guide
- [ ] I have built and run the efsity jar to verify my change fixes the issue and/or does not break the application 

